### PR TITLE
fix: database column typo and RT display issues (v2.0.1 hotfix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,3 @@
-
 # Changelog
 
 All notable changes to this project will be documented in this file.
@@ -6,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+[Unreleased]
+
+## [v2.0.1] - 2025-09-07
+
+### Hotfixes
+
+- Ensure reproduction rate always appears in json response even when null - fix rt values to always be included in api responses for consistency - update reproductionrate struct to use pointer types for proper null handling - modify transformation logic to always include rt structure - update tests to handle new pointer-based rt values - bump version to 2.0.1 for hotfix release this ensures api consumers always receive the reproduction_rate object structure, with null values when data is not available.
+
+### Fixed
+
+- Correct database column typo and ensure rt fields always present in json response - fix database column name typo from 'cumulative_finished_persoon_under_observation' to 'cumulative_finished_person_under_observation' - remove 'omitempty' from rt fields (rt, rt_upper, rt_lower) to ensure they always appear in json responses even when null - update all sql queries and tests to use correct column name - critical production hotfix for database errors and missing rt data
+
+### Maintenance
+
+- Bump version to 2.0.1 for hotfix release (version)
 
 ## [v2.0.0] - 2025-09-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-
 ## [v2.0.1] - 2025-09-07
 
 ### Hotfixes
@@ -17,24 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Correct database column typo and ensure rt fields always present in json response - fix database column name typo from 'cumulative_finished_persoon_under_observation' to 'cumulative_finished_person_under_observation' - remove 'omitempty' from rt fields (rt, rt_upper, rt_lower) to ensure they always appear in json responses even when null - update all sql queries and tests to use correct column name - critical production hotfix for database errors and missing rt data
+- Correct [Unreleased] section format in CHANGELOG.md
 
-### Documentation
+### Added
 
-- Update changelog (CHANGELOG)
-
-### Maintenance
-
-- Bump version to 2.0.1 for hotfix release (version)
-
-## [v2.0.1] - 2025-09-07
-
-### Hotfixes
-
-- Ensure reproduction rate always appears in json response even when null - fix rt values to always be included in api responses for consistency - update reproductionrate struct to use pointer types for proper null handling - modify transformation logic to always include rt structure - update tests to handle new pointer-based rt values - bump version to 2.0.1 for hotfix release this ensures api consumers always receive the reproduction_rate object structure, with null values when data is not available.
-
-### Fixed
-
-- Correct database column typo and ensure rt fields always present in json response - fix database column name typo from 'cumulative_finished_persoon_under_observation' to 'cumulative_finished_person_under_observation' - remove 'omitempty' from rt fields (rt, rt_upper, rt_lower) to ensure they always appear in json responses even when null - update all sql queries and tests to use correct column name - critical production hotfix for database errors and missing rt data
+- Add hotfix branch support to changelog generator
 
 ### Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-[Unreleased]
+## [Unreleased]
 
 ## [v2.0.1] - 2025-09-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+## [v2.0.1] - 2025-09-07
+
+### Hotfixes
+
+- Ensure reproduction rate always appears in json response even when null - fix rt values to always be included in api responses for consistency - update reproductionrate struct to use pointer types for proper null handling - modify transformation logic to always include rt structure - update tests to handle new pointer-based rt values - bump version to 2.0.1 for hotfix release this ensures api consumers always receive the reproduction_rate object structure, with null values when data is not available.
+
+### Fixed
+
+- Correct database column typo and ensure rt fields always present in json response - fix database column name typo from 'cumulative_finished_persoon_under_observation' to 'cumulative_finished_person_under_observation' - remove 'omitempty' from rt fields (rt, rt_upper, rt_lower) to ensure they always appear in json responses even when null - update all sql queries and tests to use correct column name - critical production hotfix for database errors and missing rt data
+
+### Documentation
+
+- Update changelog (CHANGELOG)
+
+### Maintenance
+
+- Bump version to 2.0.1 for hotfix release (version)
+
 ## [v2.0.1] - 2025-09-07
 
 ### Hotfixes

--- a/internal/handler/covid_handler.go
+++ b/internal/handler/covid_handler.go
@@ -137,7 +137,7 @@ func (h *CovidHandler) HealthCheck(w http.ResponseWriter, r *http.Request) {
 	health := map[string]interface{}{
 		"status":    "healthy",
 		"service":   "COVID-19 API",
-		"version":   "2.0.0",
+		"version":   "2.0.1",
 		"timestamp": time.Now().UTC().Format(time.RFC3339),
 	}
 

--- a/internal/handler/covid_handler_test.go
+++ b/internal/handler/covid_handler_test.go
@@ -286,7 +286,7 @@ func TestCovidHandler_HealthCheck(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, "degraded", data["status"])
 	assert.Equal(t, "COVID-19 API", data["service"])
-	assert.Equal(t, "2.0.0", data["version"])
+	assert.Equal(t, "2.0.1", data["version"])
 	assert.Contains(t, data, "database")
 	
 	dbData, ok := data["database"].(map[string]interface{})

--- a/internal/models/national_case.go
+++ b/internal/models/national_case.go
@@ -16,9 +16,9 @@ type NationalCase struct {
 	CumulativePositive     int64      `json:"cumulative_positive" db:"cumulative_positive"`
 	CumulativeRecovered    int64      `json:"cumulative_recovered" db:"cumulative_recovered"`
 	CumulativeDeceased     int64      `json:"cumulative_deceased" db:"cumulative_deceased"`
-	Rt                     *float64   `json:"rt,omitempty" db:"rt"`
-	RtUpper                *float64   `json:"rt_upper,omitempty" db:"rt_upper"`
-	RtLower                *float64   `json:"rt_lower,omitempty" db:"rt_lower"`
+	Rt                     *float64   `json:"rt" db:"rt"`
+	RtUpper                *float64   `json:"rt_upper" db:"rt_upper"`
+	RtLower                *float64   `json:"rt_lower" db:"rt_lower"`
 }
 
 type NullFloat64 struct {

--- a/internal/models/national_case_response.go
+++ b/internal/models/national_case_response.go
@@ -42,9 +42,9 @@ type CasePercentages struct {
 
 // ReproductionRate represents the R-value with confidence bounds
 type ReproductionRate struct {
-	Value      float64 `json:"value"`
-	UpperBound float64 `json:"upper_bound"`
-	LowerBound float64 `json:"lower_bound"`
+	Value      *float64 `json:"value"`
+	UpperBound *float64 `json:"upper_bound"`
+	LowerBound *float64 `json:"lower_bound"`
 }
 
 // TransformToResponse converts a NationalCase model to the response format
@@ -74,13 +74,11 @@ func (nc *NationalCase) TransformToResponse() NationalCaseResponse {
 		},
 	}
 
-	// Add reproduction rate if available
-	if nc.Rt != nil && nc.RtUpper != nil && nc.RtLower != nil {
-		response.Statistics.ReproductionRate = &ReproductionRate{
-			Value:      *nc.Rt,
-			UpperBound: *nc.RtUpper,
-			LowerBound: *nc.RtLower,
-		}
+	// Always include reproduction rate structure, even when values are null
+	response.Statistics.ReproductionRate = &ReproductionRate{
+		Value:      nc.Rt,
+		UpperBound: nc.RtUpper,
+		LowerBound: nc.RtLower,
 	}
 
 	return response

--- a/internal/models/national_case_response_test.go
+++ b/internal/models/national_case_response_test.go
@@ -69,14 +69,14 @@ func TestNationalCase_TransformToResponse(t *testing.T) {
 	if response.Statistics.ReproductionRate == nil {
 		t.Error("Expected ReproductionRate to be present")
 	} else {
-		if response.Statistics.ReproductionRate.Value != rtValue {
-			t.Errorf("Expected Rt.Value %f, got %f", rtValue, response.Statistics.ReproductionRate.Value)
+		if *response.Statistics.ReproductionRate.Value != rtValue {
+			t.Errorf("Expected Rt.Value %f, got %f", rtValue, *response.Statistics.ReproductionRate.Value)
 		}
-		if response.Statistics.ReproductionRate.UpperBound != rtUpper {
-			t.Errorf("Expected Rt.UpperBound %f, got %f", rtUpper, response.Statistics.ReproductionRate.UpperBound)
+		if *response.Statistics.ReproductionRate.UpperBound != rtUpper {
+			t.Errorf("Expected Rt.UpperBound %f, got %f", rtUpper, *response.Statistics.ReproductionRate.UpperBound)
 		}
-		if response.Statistics.ReproductionRate.LowerBound != rtLower {
-			t.Errorf("Expected Rt.LowerBound %f, got %f", rtLower, response.Statistics.ReproductionRate.LowerBound)
+		if *response.Statistics.ReproductionRate.LowerBound != rtLower {
+			t.Errorf("Expected Rt.LowerBound %f, got %f", rtLower, *response.Statistics.ReproductionRate.LowerBound)
 		}
 	}
 
@@ -103,8 +103,18 @@ func TestNationalCase_TransformToResponse_NoReproductionRate(t *testing.T) {
 
 	response := nc.TransformToResponse()
 
-	if response.Statistics.ReproductionRate != nil {
-		t.Error("Expected ReproductionRate to be nil when not provided")
+	if response.Statistics.ReproductionRate == nil {
+		t.Error("Expected ReproductionRate to always be present")
+	} else {
+		if response.Statistics.ReproductionRate.Value != nil {
+			t.Error("Expected Rt.Value to be nil when not provided")
+		}
+		if response.Statistics.ReproductionRate.UpperBound != nil {
+			t.Error("Expected Rt.UpperBound to be nil when not provided")
+		}
+		if response.Statistics.ReproductionRate.LowerBound != nil {
+			t.Error("Expected Rt.LowerBound to be nil when not provided")
+		}
 	}
 }
 

--- a/internal/models/province_case.go
+++ b/internal/models/province_case.go
@@ -17,12 +17,12 @@ type ProvinceCase struct {
 	CumulativeRecovered                              int64     `json:"cumulative_recovered" db:"cumulative_recovered"`
 	CumulativeDeceased                               int64     `json:"cumulative_deceased" db:"cumulative_deceased"`
 	CumulativePersonUnderObservation                 int64     `json:"cumulative_person_under_observation" db:"cumulative_person_under_observation"`
-	CumulativeFinishedPersonUnderObservation         int64     `json:"cumulative_finished_person_under_observation" db:"cumulative_finished_persoon_under_observation"`
+	CumulativeFinishedPersonUnderObservation         int64     `json:"cumulative_finished_person_under_observation" db:"cumulative_finished_person_under_observation"`
 	CumulativePersonUnderSupervision                 int64     `json:"cumulative_person_under_supervision" db:"cumulative_person_under_supervision"`
 	CumulativeFinishedPersonUnderSupervision         int64     `json:"cumulative_finished_person_under_supervision" db:"cumulative_finished_person_under_supervision"`
-	Rt                                               *float64  `json:"rt,omitempty" db:"rt"`
-	RtUpper                                          *float64  `json:"rt_upper,omitempty" db:"rt_upper"`
-	RtLower                                          *float64  `json:"rt_lower,omitempty" db:"rt_lower"`
+	Rt                                               *float64  `json:"rt" db:"rt"`
+	RtUpper                                          *float64  `json:"rt_upper" db:"rt_upper"`
+	RtLower                                          *float64  `json:"rt_lower" db:"rt_lower"`
 	Province                                         *Province `json:"province,omitempty"`
 }
 

--- a/internal/models/province_case_response.go
+++ b/internal/models/province_case_response.go
@@ -41,7 +41,7 @@ type ProvinceCumulativeCases struct {
 // ProvinceCaseStatistics contains calculated statistics and metrics for province data
 type ProvinceCaseStatistics struct {
 	Percentages      CasePercentages   `json:"percentages"`
-	ReproductionRate *ReproductionRate `json:"reproduction_rate,omitempty"`
+	ReproductionRate *ReproductionRate `json:"reproduction_rate"`
 }
 
 // TransformToResponse converts a ProvinceCase model to the response format
@@ -86,13 +86,11 @@ func (pc *ProvinceCase) TransformToResponse(date time.Time) ProvinceCaseResponse
 		Province: pc.Province,
 	}
 
-	// Add reproduction rate if available
-	if pc.Rt != nil && pc.RtUpper != nil && pc.RtLower != nil {
-		response.Statistics.ReproductionRate = &ReproductionRate{
-			Value:      *pc.Rt,
-			UpperBound: *pc.RtUpper,
-			LowerBound: *pc.RtLower,
-		}
+	// Always include reproduction rate structure, even when values are null
+	response.Statistics.ReproductionRate = &ReproductionRate{
+		Value:      pc.Rt,
+		UpperBound: pc.RtUpper,
+		LowerBound: pc.RtLower,
 	}
 
 	return response

--- a/internal/models/province_case_response_test.go
+++ b/internal/models/province_case_response_test.go
@@ -151,7 +151,11 @@ func TestProvinceCase_TransformToResponse(t *testing.T) {
 						Recovered: 90.0, // (1800 / 2000) * 100
 						Deceased:  5.0,  // (100 / 2000) * 100
 					},
-					ReproductionRate: nil,
+					ReproductionRate: &ReproductionRate{
+						Value:      nil,
+						UpperBound: nil,
+						LowerBound: nil,
+					},
 				},
 				Province: &Province{
 					ID:   "ID-JB",
@@ -219,7 +223,11 @@ func TestProvinceCase_TransformToResponse(t *testing.T) {
 						Recovered: 0.0,
 						Deceased:  0.0,
 					},
-					ReproductionRate: nil,
+					ReproductionRate: &ReproductionRate{
+						Value:      nil,
+						UpperBound: nil,
+						LowerBound: nil,
+					},
 				},
 				Province: &Province{
 					ID:   "ID-AC",

--- a/internal/models/province_case_response_test.go
+++ b/internal/models/province_case_response_test.go
@@ -80,9 +80,9 @@ func TestProvinceCase_TransformToResponse(t *testing.T) {
 						Deceased:  6.0,  // (300 / 5000) * 100
 					},
 					ReproductionRate: &ReproductionRate{
-						Value:      1.5,
-						UpperBound: 1.8,
-						LowerBound: 1.2,
+						Value:      &[]float64{1.5}[0],
+						UpperBound: &[]float64{1.8}[0],
+						LowerBound: &[]float64{1.2}[0],
 					},
 				},
 				Province: &Province{
@@ -307,9 +307,9 @@ func TestProvinceCaseWithDate_TransformToResponse(t *testing.T) {
 				Deceased:  6.666666666666667, // (200 / 3000) * 100
 			},
 			ReproductionRate: &ReproductionRate{
-				Value:      1.2,
-				UpperBound: 1.5,
-				LowerBound: 0.9,
+				Value:      &[]float64{1.2}[0],
+				UpperBound: &[]float64{1.5}[0],
+				LowerBound: &[]float64{0.9}[0],
 			},
 		},
 		Province: &Province{

--- a/internal/repository/province_case_repository.go
+++ b/internal/repository/province_case_repository.go
@@ -30,7 +30,7 @@ func (r *provinceCaseRepository) GetAll() ([]models.ProvinceCaseWithDate, error)
 			  pc.person_under_observation, pc.finished_person_under_observation,
 			  pc.person_under_supervision, pc.finished_person_under_supervision,
 			  pc.cumulative_positive, pc.cumulative_recovered, pc.cumulative_deceased,
-			  pc.cumulative_person_under_observation, pc.cumulative_finished_persoon_under_observation,
+			  pc.cumulative_person_under_observation, pc.cumulative_finished_person_under_observation,
 			  pc.cumulative_person_under_supervision, pc.cumulative_finished_person_under_supervision,
 			  pc.rt, pc.rt_upper, pc.rt_lower, nc.date, p.name
 			  FROM province_cases pc
@@ -46,7 +46,7 @@ func (r *provinceCaseRepository) GetByProvinceID(provinceID string) ([]models.Pr
 			  pc.person_under_observation, pc.finished_person_under_observation,
 			  pc.person_under_supervision, pc.finished_person_under_supervision,
 			  pc.cumulative_positive, pc.cumulative_recovered, pc.cumulative_deceased,
-			  pc.cumulative_person_under_observation, pc.cumulative_finished_persoon_under_observation,
+			  pc.cumulative_person_under_observation, pc.cumulative_finished_person_under_observation,
 			  pc.cumulative_person_under_supervision, pc.cumulative_finished_person_under_supervision,
 			  pc.rt, pc.rt_upper, pc.rt_lower, nc.date, p.name
 			  FROM province_cases pc
@@ -63,7 +63,7 @@ func (r *provinceCaseRepository) GetByProvinceIDAndDateRange(provinceID string, 
 			  pc.person_under_observation, pc.finished_person_under_observation,
 			  pc.person_under_supervision, pc.finished_person_under_supervision,
 			  pc.cumulative_positive, pc.cumulative_recovered, pc.cumulative_deceased,
-			  pc.cumulative_person_under_observation, pc.cumulative_finished_persoon_under_observation,
+			  pc.cumulative_person_under_observation, pc.cumulative_finished_person_under_observation,
 			  pc.cumulative_person_under_supervision, pc.cumulative_finished_person_under_supervision,
 			  pc.rt, pc.rt_upper, pc.rt_lower, nc.date, p.name
 			  FROM province_cases pc
@@ -80,7 +80,7 @@ func (r *provinceCaseRepository) GetByDateRange(startDate, endDate time.Time) ([
 			  pc.person_under_observation, pc.finished_person_under_observation,
 			  pc.person_under_supervision, pc.finished_person_under_supervision,
 			  pc.cumulative_positive, pc.cumulative_recovered, pc.cumulative_deceased,
-			  pc.cumulative_person_under_observation, pc.cumulative_finished_persoon_under_observation,
+			  pc.cumulative_person_under_observation, pc.cumulative_finished_person_under_observation,
 			  pc.cumulative_person_under_supervision, pc.cumulative_finished_person_under_supervision,
 			  pc.rt, pc.rt_upper, pc.rt_lower, nc.date, p.name
 			  FROM province_cases pc
@@ -97,7 +97,7 @@ func (r *provinceCaseRepository) GetLatestByProvinceID(provinceID string) (*mode
 			  pc.person_under_observation, pc.finished_person_under_observation,
 			  pc.person_under_supervision, pc.finished_person_under_supervision,
 			  pc.cumulative_positive, pc.cumulative_recovered, pc.cumulative_deceased,
-			  pc.cumulative_person_under_observation, pc.cumulative_finished_persoon_under_observation,
+			  pc.cumulative_person_under_observation, pc.cumulative_finished_person_under_observation,
 			  pc.cumulative_person_under_supervision, pc.cumulative_finished_person_under_supervision,
 			  pc.rt, pc.rt_upper, pc.rt_lower, nc.date, p.name
 			  FROM province_cases pc

--- a/internal/repository/province_case_repository_test.go
+++ b/internal/repository/province_case_repository_test.go
@@ -26,7 +26,7 @@ func TestProvinceCaseRepository_GetAll(t *testing.T) {
 		"person_under_observation", "finished_person_under_observation",
 		"person_under_supervision", "finished_person_under_supervision",
 		"cumulative_positive", "cumulative_recovered", "cumulative_deceased",
-		"cumulative_person_under_observation", "cumulative_finished_persoon_under_observation",
+		"cumulative_person_under_observation", "cumulative_finished_person_under_observation",
 		"cumulative_person_under_supervision", "cumulative_finished_person_under_supervision",
 		"rt", "rt_upper", "rt_lower", "date", "name",
 	}).AddRow(1, 1, "11", 50, 40, 2, 10, 8, 5, 3, 500, 400, 20, 100, 80, 50, 30, rt, nil, nil, now, "Aceh")
@@ -66,7 +66,7 @@ func TestProvinceCaseRepository_GetByProvinceID(t *testing.T) {
 		"person_under_observation", "finished_person_under_observation",
 		"person_under_supervision", "finished_person_under_supervision",
 		"cumulative_positive", "cumulative_recovered", "cumulative_deceased",
-		"cumulative_person_under_observation", "cumulative_finished_persoon_under_observation",
+		"cumulative_person_under_observation", "cumulative_finished_person_under_observation",
 		"cumulative_person_under_supervision", "cumulative_finished_person_under_supervision",
 		"rt", "rt_upper", "rt_lower", "date", "name",
 	}).AddRow(1, 1, provinceID, 50, 40, 2, 10, 8, 5, 3, 500, 400, 20, 100, 80, 50, 30, nil, nil, nil, now, "Aceh")
@@ -105,7 +105,7 @@ func TestProvinceCaseRepository_GetByProvinceIDAndDateRange(t *testing.T) {
 		"person_under_observation", "finished_person_under_observation",
 		"person_under_supervision", "finished_person_under_supervision",
 		"cumulative_positive", "cumulative_recovered", "cumulative_deceased",
-		"cumulative_person_under_observation", "cumulative_finished_persoon_under_observation",
+		"cumulative_person_under_observation", "cumulative_finished_person_under_observation",
 		"cumulative_person_under_supervision", "cumulative_finished_person_under_supervision",
 		"rt", "rt_upper", "rt_lower", "date", "name",
 	}).AddRow(1, 1, provinceID, 50, 40, 2, 10, 8, 5, 3, 500, 400, 20, 100, 80, 50, 30, nil, nil, nil, now, "Aceh")
@@ -142,7 +142,7 @@ func TestProvinceCaseRepository_GetLatestByProvinceID(t *testing.T) {
 		"person_under_observation", "finished_person_under_observation",
 		"person_under_supervision", "finished_person_under_supervision",
 		"cumulative_positive", "cumulative_recovered", "cumulative_deceased",
-		"cumulative_person_under_observation", "cumulative_finished_persoon_under_observation",
+		"cumulative_person_under_observation", "cumulative_finished_person_under_observation",
 		"cumulative_person_under_supervision", "cumulative_finished_person_under_supervision",
 		"rt", "rt_upper", "rt_lower", "date", "name",
 	}).AddRow(1, 1, provinceID, 50, 40, 2, 10, 8, 5, 3, 500, 400, 20, 100, 80, 50, 30, rt, nil, nil, now, "Aceh")
@@ -178,7 +178,7 @@ func TestProvinceCaseRepository_GetLatestByProvinceID_NotFound(t *testing.T) {
 		"person_under_observation", "finished_person_under_observation",
 		"person_under_supervision", "finished_person_under_supervision",
 		"cumulative_positive", "cumulative_recovered", "cumulative_deceased",
-		"cumulative_person_under_observation", "cumulative_finished_persoon_under_observation",
+		"cumulative_person_under_observation", "cumulative_finished_person_under_observation",
 		"cumulative_person_under_supervision", "cumulative_finished_person_under_supervision",
 		"rt", "rt_upper", "rt_lower", "date", "name",
 	})


### PR DESCRIPTION
## Summary
- Fix database column typo: `cumulative_finished_persoon_under_observation` → `cumulative_finished_person_under_observation`
- Fix RT values not showing in JSON by using pointer types (*float64) and removing omitempty tags
- Update tests to reflect corrected column names
- Bump version to 2.0.1 in tests

## Test plan
- [x] Unit tests pass with corrected column names
- [x] RT values now properly display in JSON even when null
- [x] Database queries no longer throw "Unknown column" errors