### PR TITLE
fix(docker): bump alpine runtime base to clear libcrypto3 CVE-2026-31789

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build \
     ./cmd/
 
 # ---- Runtime image ----
-FROM alpine:3.21
+FROM alpine:3.22
 
 RUN apk --no-cache add ca-certificates tzdata
 


### PR DESCRIPTION
## Summary

- Bumps runtime stage `FROM alpine:3.21` → `FROM alpine:3.22` to clear the CRITICAL `libcrypto3` CVE-2026-31789 (OpenSSL heap buffer overflow on 32-bit systems) present in the stale `alpine:3.21.6` base of the current deployed image.

## Trivy scan results

**Before** (`ghcr.io/banua-coder/pico-api-go:latest` — built on alpine 3.21.6):
| Severity | Count | Notable CVEs |
|----------|-------|--------------|
| CRITICAL | 2 | CVE-2026-31789 (libcrypto3 + libssl3) |
| HIGH | 11 | CVE-2026-28387/28388/28389/28390 (OpenSSL), CVE-2026-40200 (musl), CVE-2026-22184 (zlib) |

**After** (`alpine:3.22` — verified on VPS via `trivy image alpine:3.22`):
| Severity | Count | Notable CVEs |
|----------|-------|--------------|
| CRITICAL | 0 | — CVE-2026-31789 absent |
| HIGH | 2 | CVE-2026-45447 (different OpenSSL issue, fixedVersion = 3.5.7-r0) |

CVE-2026-31789 is fully cleared. Reduction: 2 CRITICAL + 11 HIGH → 0 CRITICAL + 2 HIGH (OS layer).

## Test plan

- [ ] CI builds the Docker image on this branch (or manually: `docker build -t pico-api-go:test .`)
- [ ] Run `trivy image pico-api-go:test --severity HIGH,CRITICAL` and confirm CVE-2026-31789 is absent and CRITICAL count is 0
- [ ] Merge to develop → tag `v<next>` triggers deploy to VPS

Fixes bead d8a7.